### PR TITLE
corrected missing staging installation for openal and physfs

### DIFF
--- a/package/openal/openal.mk
+++ b/package/openal/openal.mk
@@ -8,12 +8,6 @@ OPENAL_SOURCE = openal-soft-$(OPENAL_VERSION).tar.gz
 OPENAL_SITE = https://github.com/JogAmp/openal-soft/archive
 OPENAL_LICENCE = GPL
 OPENAL_DEPENDENCIES = 
-
-define OPENAL_RPI_FIXUP.in
-	$(SED) 's|/opt/vc/include|$(STAGING_DIR)/usr/include|g' $(@D)/CMakeLists.txt
-	$(SED) 's|/opt/vc/lib|$(STAGING_DIR)/usr/lib|g' $(@D)/CMakeLists.txt
-endef
-
-OPENAL_PRE_CONFIGURE_HOOKS += OPENAL_RPI_FIXUP
+OPENAL_INSTALL_STAGING = YES
 
 $(eval $(cmake-package))

--- a/package/physfs/physfs.mk
+++ b/package/physfs/physfs.mk
@@ -8,12 +8,6 @@ PHYSFS_SOURCE = physfs-$(PHYSFS_VERSION).tar.bz2
 PHYSFS_SITE =  http://icculus.org/physfs/downloads
 PHYSFS_LICENCE = GPL
 PHYSFS_DEPENDENCIES = 
-
-define PHYSFS_RPI_FIXUP.in
-	$(SED) 's|/opt/vc/include|$(STAGING_DIR)/usr/include|g' $(@D)/CMakeLists.txt
-	$(SED) 's|/opt/vc/lib|$(STAGING_DIR)/usr/lib|g' $(@D)/CMakeLists.txt
-endef
-
-PHYSFS_PRE_CONFIGURE_HOOKS += PHYSFS_RPI_FIXUP
+PHYSFS_INSTALL_STAGING = YES
 
 $(eval $(cmake-package))

--- a/package/zeldasolarusdx/Config.in
+++ b/package/zeldasolarusdx/Config.in
@@ -1,11 +1,10 @@
 config BR2_PACKAGE_ZELDASOLARUSDX
         bool "zeldasolarusdx"
 	depends on BR2_INSTALL_LIBSTDCPP
-	depends on BR2_PACKAGE_LIBPTHREAD_STUBS
 	depends on BR2_PACKAGE_SDL2
-	depends on BR2_PACKAGE_VORBIS_TOOLS
-	depends on BR2_PACKAGE_MODPLUGTOOLS
-	depends on BR2_PACKAGE_LUA_5_1
+	select BR2_PACKAGE_VORBIS_TOOLS
+	select BR2_PACKAGE_MODPLUGTOOLS
+	select BR2_PACKAGE_LUAJIT
         select BR2_PACKAGE_OPENAL 
 	select BR2_PACKAGE_PHYSFS
 	select BR2_PACKAGE_SDL2_IMAGE
@@ -15,8 +14,5 @@ config BR2_PACKAGE_ZELDASOLARUSDX
 	  https://github.com/christopho/solarus/
 
 comment "Zelda Solarus needs a toolchain w/ C++, LUA, Openal, vorbistools , modplugtools, physfs and SDL2"
-	depends on !BR2_INSTALL_LIBSTDCPP || !BR2_PACKAGE_LIBPTHREAD_STUBS || \
-		!BR2_PACKAGE_SDL2 || !BR2_PACKAGE_VORBIS_TOOLS || \
-		!BR2_PACKAGE_MODPLUGTOOLS || !BR2_PACKAGE_LUA_5_1 
-		
-	
+	depends on !BR2_INSTALL_LIBSTDCPP || \
+		!BR2_PACKAGE_SDL2 

--- a/package/zeldasolarusdx/zeldasolarusdx.mk
+++ b/package/zeldasolarusdx/zeldasolarusdx.mk
@@ -7,7 +7,7 @@ ZELDASOLARUSDX_VERSION = 1.4.1
 ZELDASOLARUSDX_SOURCE = v$(ZELDASOLARUSDX_VERSION).tar.gz
 ZELDASOLARUSDX_SITE = https://github.com/christopho/solarus/archive
 ZELDASOLARUSDX_LICENCE = GPL
-ZELDASOLARUSDX_DEPENDENCIES = libpthread-stubs sdl2 sdl2_image sdl2_ttf openal vorbis-tools modplugtools lua physfs
+ZELDASOLARUSDX_DEPENDENCIES = libpthread-stubs sdl2 sdl2_image sdl2_ttf openal vorbis-tools modplugtools luajit physfs
 
 define ZELDASOLARUSDX_RPI_FIXUP.in
 	$(SED) 's|/opt/vc/include|$(STAGING_DIR)/usr/include|g' $(@D)/CMakeLists.txt
@@ -15,5 +15,14 @@ define ZELDASOLARUSDX_RPI_FIXUP.in
 endef
 
 ZELDASOLARUSDX_PRE_CONFIGURE_HOOKS += ZELDASOLARUSDX_RPI_FIXUP
+
+# Just copy the binary and lib, maybe we should copy more things after tests
+define ZELDASOLARUSDX_INSTALL_TARGET_CMDS
+	$(INSTALL) -D $(@D)/solarus_run \
+		$(TARGET_DIR)/usr/games/zeldasolarusdx/solarus_run
+	$(INSTALL) -D $(@D)/libsolarus.so \
+                $(TARGET_DIR)/usr/games/zeldasolarusdx/libsolarus.so
+
+endef
 
 $(eval $(cmake-package))


### PR DESCRIPTION
modified dependencies and install process of zeldasolarus

Check the XXXXXX_INSTALL_STAGING = YES that install in the staging dir (accessible at compile time for other packages)

I just "selected" some libs in place of using "depends on" to simplify the install process, 

And finally look at the custom +define ZELDASOLARUSDX_INSTALL_TARGET_CMDS
that override the standard install, avoiding the copy of headers.
